### PR TITLE
Bump hackney to 1.7.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule HTTPipe.Adapters.Hackney.Mixfile do
     [
       {:earmark, "~> 1.0", only: [:dev, :docs]},
       {:ex_doc, "~> 0.13", only: [:dev, :docs]},
-      {:hackney, "~> 1.6.0"},
+      {:hackney, "~> 1.7.0"},
       {:httpipe, "~> 0.9.0"},
     ]
   end


### PR DESCRIPTION
hackney 1.7.0 fixes a serious HTTP headers bug introduced in 1.6.6. See benoitc/hackney#388.